### PR TITLE
Adjust wolf step height and only follow owner while unsaddled.

### DIFF
--- a/src/main/java/com/teammetallurgy/atum/entity/ai/EntityAIFollowOwnerWithoutSaddle.java
+++ b/src/main/java/com/teammetallurgy/atum/entity/ai/EntityAIFollowOwnerWithoutSaddle.java
@@ -11,9 +11,7 @@ public class EntityAIFollowOwnerWithoutSaddle extends EntityAIFollowOwner {
         this.wolf = tameableIn;
     }
 
-    /**
-     * Returns whether the EntityAIBase should begin execution.
-     */
+    @Override
     public boolean shouldExecute() {
         if (wolf.isSaddled()) return false;
         return super.shouldExecute();

--- a/src/main/java/com/teammetallurgy/atum/entity/ai/EntityAIFollowOwnerWithoutSaddle.java
+++ b/src/main/java/com/teammetallurgy/atum/entity/ai/EntityAIFollowOwnerWithoutSaddle.java
@@ -1,0 +1,21 @@
+package com.teammetallurgy.atum.entity.ai;
+
+import com.teammetallurgy.atum.entity.animal.EntityDesertWolf;
+import net.minecraft.entity.ai.EntityAIFollowOwner;
+
+public class EntityAIFollowOwnerWithoutSaddle extends EntityAIFollowOwner {
+    private final EntityDesertWolf wolf;
+
+    public EntityAIFollowOwnerWithoutSaddle(EntityDesertWolf tameableIn, double followSpeedIn, float minDistIn, float maxDistIn) {
+        super(tameableIn, followSpeedIn, minDistIn, maxDistIn);
+        this.wolf = tameableIn;
+    }
+
+    /**
+     * Returns whether the EntityAIBase should begin execution.
+     */
+    public boolean shouldExecute() {
+        if (wolf.isSaddled()) return false;
+        return super.shouldExecute();
+    }
+}

--- a/src/main/java/com/teammetallurgy/atum/entity/animal/EntityDesertWolf.java
+++ b/src/main/java/com/teammetallurgy/atum/entity/animal/EntityDesertWolf.java
@@ -4,6 +4,7 @@ import com.google.common.base.Predicate;
 import com.teammetallurgy.atum.Atum;
 import com.teammetallurgy.atum.entity.ai.AIBeg;
 import com.teammetallurgy.atum.entity.ai.AISitWithCheck;
+import com.teammetallurgy.atum.entity.ai.EntityAIFollowOwnerWithoutSaddle;
 import com.teammetallurgy.atum.entity.undead.EntityUndeadBase;
 import com.teammetallurgy.atum.init.AtumBlocks;
 import com.teammetallurgy.atum.init.AtumItems;
@@ -87,7 +88,7 @@ public class EntityDesertWolf extends EntityTameable implements IJumpingMount, I
         this.setAngry(true);
         this.setTamed(false);
         this.experienceValue = 6;
-        this.stepHeight = 1.1F;
+        this.stepHeight = 1.4F;
         MinecraftForge.EVENT_BUS.register(this);
         this.initInventory();
     }
@@ -102,7 +103,7 @@ public class EntityDesertWolf extends EntityTameable implements IJumpingMount, I
         this.tasks.addTask(3, new EntityAIAvoidEntity<>(this, EntityCamel.class, 24.0F, 0.6D, 1.2D));
         this.tasks.addTask(4, new EntityAILeapAtTarget(this, 0.4F));
         this.tasks.addTask(5, new EntityAIAttackMelee(this, 1.0D, true));
-        this.tasks.addTask(6, new EntityAIFollowOwner(this, 1.0D, 10.0F, 2.0F));
+        this.tasks.addTask(6, new EntityAIFollowOwnerWithoutSaddle(this, 1.0D, 10.0F, 2.0F));
         this.tasks.addTask(7, new EntityAIMate(this, 1.0D));
         this.tasks.addTask(8, new EntityAIWanderAvoidWater(this, 1.0D));
         this.tasks.addTask(9, new AIBeg(this, 8.0F));

--- a/src/main/java/com/teammetallurgy/atum/entity/animal/EntityDesertWolf.java
+++ b/src/main/java/com/teammetallurgy/atum/entity/animal/EntityDesertWolf.java
@@ -88,7 +88,7 @@ public class EntityDesertWolf extends EntityTameable implements IJumpingMount, I
         this.setAngry(true);
         this.setTamed(false);
         this.experienceValue = 6;
-        this.stepHeight = 1.4F;
+        this.stepHeight = 1.1F;
         MinecraftForge.EVENT_BUS.register(this);
         this.initInventory();
     }


### PR DESCRIPTION
Step height of 1.6 is a little too much, 1.4 seems to be sufficient, but
1.1 isn't quite enough to overcome all of the blocks in the Atum2 dimension.

However, it's speed will result in a lot of "Entity Desert Wolf moved
wrongly!" messages being spammed in chat. It has to do with the speed at
which something moves vertically (i.e., with step assist). Other than
the warning, it should have no other effect. Reducing the overall speed
of the mob may help.

I've only had that issue with the Botania skelefied horses/zombified
horses.

The new EntityAIFollowOwnerWithoutSaddle task literally derives from
EntityAIFollowOwner, and simply overrides should execute to fail early
if the entity is saddled.