### PR TITLE
Do not use the server world when creating particles on the client

### DIFF
--- a/src/main/java/com/teammetallurgy/atum/proxy/ClientProxy.java
+++ b/src/main/java/com/teammetallurgy/atum/proxy/ClientProxy.java
@@ -160,6 +160,6 @@ public class ClientProxy extends CommonProxy {
 
     @Override
     public void spawnParticle(AtumParticles.Types particleType, Entity entity, double x, double y, double z, double xSpeed, double ySpeed, double zSpeed) {
-        ClientProxy.atumParticles.addEffect(ClientProxy.atumParticles.spawnEffectParticle(particleType.getParticleName(), entity.world, x, y, z, xSpeed, ySpeed, zSpeed));
+        ClientProxy.atumParticles.addEffect(ClientProxy.atumParticles.spawnEffectParticle(particleType.getParticleName(), Minecraft.getMinecraft().world, x, y, z, xSpeed, ySpeed, zSpeed));
     }
 }


### PR DESCRIPTION
Fixes #85 which was caused by the client proxy passing the server's world to the client-side particle constructor. Client entities should never have access to the server's data, as it can introduce subtle issues by mutating server state on the client thread.