### PR TITLE
Really small change to Nebu Block name

### DIFF
--- a/src/main/resources/assets/atum/lang/en_us.json
+++ b/src/main/resources/assets/atum/lang/en_us.json
@@ -256,7 +256,7 @@
   "block.atum.bone_ore": "Bone Ore",
   "block.atum.relic_ore": "Relic Ore",
   "block.atum.nebu_ore": "Nebu Ore",
-  "block.atum.nebu_block": "Nebu Block",
+  "block.atum.nebu_block": "Block of Nebu",
   "block.atum.godforged_block": "Godforged Block",
   "block.atum.anput_godforged_block": "Anput Godforged Block",
   "block.atum.anubis_godforged_block": "Anubis Godforged Block",


### PR DESCRIPTION
A small point that was annoying me in a few mods like Occultism, Psi and Atum. I'm just making some tiny PRs to fix it.
Nebu Block has been changed to Block of Nebu to comply with vanilla naming (e.g. Block of Gold, Block of Iron). That's it.