### PR TITLE
Made Atum biome source return the correct biome instances

### DIFF
--- a/src/main/java/com/teammetallurgy/atum/world/DimensionHelper.java
+++ b/src/main/java/com/teammetallurgy/atum/world/DimensionHelper.java
@@ -13,7 +13,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.MutableBoundingBox;
 import net.minecraft.util.registry.Registry;
-import net.minecraft.util.registry.WorldGenRegistries;
 import net.minecraft.world.ISeedReader;
 import net.minecraft.world.IWorld;
 import net.minecraft.world.World;
@@ -85,14 +84,6 @@ public class DimensionHelper {
             pos = pos.up();
         }
         return pos;
-    }
-
-    public static Biome getBiome(RegistryKey<Biome> key) {
-        return WorldGenRegistries.BIOME.getValueForKey(key);
-    }
-
-    public static int getBiomeID(RegistryKey<Biome> key) {
-        return WorldGenRegistries.BIOME.getId(getBiome(key));
     }
 
     public static boolean isBeatenPyramid(ServerWorld serverWorld, MutableBoundingBox box2) {

--- a/src/main/java/com/teammetallurgy/atum/world/biome/AtumBiomeProvider.java
+++ b/src/main/java/com/teammetallurgy/atum/world/biome/AtumBiomeProvider.java
@@ -4,15 +4,16 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.teammetallurgy.atum.misc.AtumRegistry;
 import com.teammetallurgy.atum.world.gen.layer.AtumLayerUtil;
-import net.minecraft.util.RegistryKey;
+import net.minecraft.util.SharedConstants;
+import net.minecraft.util.Util;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.util.registry.RegistryLookupCodec;
 import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.BiomeRegistry;
 import net.minecraft.world.biome.provider.BiomeProvider;
 import net.minecraft.world.gen.layer.Layer;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
-import net.minecraftforge.registries.ForgeRegistries;
 
 import javax.annotation.Nonnull;
 import java.util.Random;
@@ -22,7 +23,7 @@ public class AtumBiomeProvider extends BiomeProvider {
     public static final Codec<AtumBiomeProvider> CODEC = RecordCodecBuilder.create((builder) -> {
         return builder.group(Codec.BOOL.fieldOf("large_biomes").orElse(false).stable().forGetter((atumBiomeProvider) -> {
             return atumBiomeProvider.largeBiomes;
-        }), RegistryLookupCodec.getLookUpCodec(ForgeRegistries.Keys.BIOMES).forGetter((atumBiomeProvider) -> {
+        }), RegistryLookupCodec.getLookUpCodec(Registry.BIOME_KEY).forGetter((atumBiomeProvider) -> {
             return atumBiomeProvider.lookupRegistry;
         })).apply(builder, builder.stable(AtumBiomeProvider::new));
     });
@@ -31,19 +32,11 @@ public class AtumBiomeProvider extends BiomeProvider {
     private final Registry<Biome> lookupRegistry;
 
     public AtumBiomeProvider(boolean largeBiomes, Registry<Biome> lookupRegistry) {
-        super(AtumRegistry.BIOME_KEYS.stream().map(AtumBiomeProvider::getBiome).collect(Collectors.toList()));
+        super(AtumRegistry.BIOME_KEYS.stream().map(lookupRegistry::getOrThrow).collect(Collectors.toList()));
         long seed = (new Random()).nextLong(); //Workaround for vanilla bug, not applying seeds to biomes properly. TODO Revisit in 1.17
         this.largeBiomes = largeBiomes;
         this.lookupRegistry = lookupRegistry;
-        this.genBiomes = AtumLayerUtil.getNoiseLayer(seed, largeBiomes ? 6 : 4, 6);
-    }
-
-    public static Biome getBiome(RegistryKey<Biome> key) {
-        Biome biome = ForgeRegistries.BIOMES.getValue(key.getLocation());
-        if (biome == null) {
-            throw new RuntimeException("Attempted to get unregistered biome " + key);
-        }
-        return biome;
+        this.genBiomes = AtumLayerUtil.getNoiseLayer(seed, largeBiomes ? 6 : 4, 6, lookupRegistry);
     }
 
     @Override
@@ -59,9 +52,37 @@ public class AtumBiomeProvider extends BiomeProvider {
         return new AtumBiomeProvider(this.largeBiomes, this.lookupRegistry);
     }
 
+    /**
+     * Returns the correct dynamic registry biome instead of using func_242936_a method
+     * which actually returns the incorrect biome instance because it resolves the biome
+     * with WorldGenRegistry first instead of the dynamic registry which is... bad.
+     */
     @Override
     @Nonnull
     public Biome getNoiseBiome(int x, int y, int z) {
-        return this.genBiomes.func_242936_a(this.lookupRegistry, x, z);
+        int k = this.genBiomes.field_215742_b.getValue(x, z);
+        Biome biome = this.lookupRegistry.getByValue(k);
+
+        if (biome != null) {
+            // Dynamic Registry biome (this should always be returned ideally)
+            return biome;
+        }
+        else {
+            //fallback to WorldGenRegistry registry if dynamic registry doesn't have biome
+            if (SharedConstants.developmentMode) {
+                throw Util.pauseDevMode(new IllegalStateException("Unknown biome id: " + k));
+            }
+            else {
+                biome = this.lookupRegistry.getValueForKey(BiomeRegistry.getKeyFromID(0));
+                if(biome == null){
+                    // If this is reached, it is the end of the world lol
+                    return BiomeRegistry.THE_VOID;
+                }
+                else{
+                    // WorldGenRegistry biome (this is not good but we need to return something)
+                    return biome;
+                }
+            }
+        }
     }
 }

--- a/src/main/java/com/teammetallurgy/atum/world/gen/layer/AtumBiomeLayer.java
+++ b/src/main/java/com/teammetallurgy/atum/world/gen/layer/AtumBiomeLayer.java
@@ -6,7 +6,7 @@ import com.teammetallurgy.atum.misc.AtumRegistry;
 import net.minecraft.util.RegistryKey;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.WeightedRandom;
-import net.minecraft.util.registry.WorldGenRegistries;
+import net.minecraft.util.registry.Registry;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.gen.INoiseRandom;
 import net.minecraft.world.gen.layer.traits.IC0Transformer;
@@ -17,8 +17,10 @@ import java.util.List;
 
 public class AtumBiomeLayer implements IC0Transformer {
     private final List<BiomeEntry> biomes = Lists.newArrayList();
+    private final Registry<Biome> biomeRegistry;
 
-    public AtumBiomeLayer() {
+    public AtumBiomeLayer(Registry<Biome> biomeRegistry) {
+        this.biomeRegistry = biomeRegistry;
         for (RegistryKey<Biome> biomeKey : AtumRegistry.BIOME_KEYS) {
             ResourceLocation location = biomeKey.getLocation();
             if (location != null) {
@@ -39,6 +41,6 @@ public class AtumBiomeLayer implements IC0Transformer {
         List<BiomeEntry> biomeList = this.biomes;
         int totalWeight = WeightedRandom.getTotalWeight(biomeList);
         int weight = noiseRandom.random(totalWeight);
-        return WorldGenRegistries.BIOME.getId(WorldGenRegistries.BIOME.getValueForKey(WeightedRandom.getRandomItem(biomeList, weight).getKey()));
+        return biomeRegistry.getId(biomeRegistry.getValueForKey(WeightedRandom.getRandomItem(biomeList, weight).getKey()));
     }
 }

--- a/src/main/java/com/teammetallurgy/atum/world/gen/layer/AtumLayerUtil.java
+++ b/src/main/java/com/teammetallurgy/atum/world/gen/layer/AtumLayerUtil.java
@@ -1,23 +1,32 @@
 package com.teammetallurgy.atum.world.gen.layer;
 
 import com.teammetallurgy.atum.init.AtumBiomes;
-import com.teammetallurgy.atum.world.DimensionHelper;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.world.biome.Biome;
 import net.minecraft.world.gen.IExtendedNoiseRandom;
 import net.minecraft.world.gen.LazyAreaLayerContext;
 import net.minecraft.world.gen.area.IArea;
 import net.minecraft.world.gen.area.IAreaFactory;
 import net.minecraft.world.gen.area.LazyArea;
-import net.minecraft.world.gen.layer.*;
+import net.minecraft.world.gen.layer.EdgeBiomeLayer;
+import net.minecraft.world.gen.layer.EdgeLayer;
+import net.minecraft.world.gen.layer.HillsLayer;
+import net.minecraft.world.gen.layer.IslandLayer;
+import net.minecraft.world.gen.layer.Layer;
+import net.minecraft.world.gen.layer.LayerUtil;
+import net.minecraft.world.gen.layer.SmoothLayer;
+import net.minecraft.world.gen.layer.StartRiverLayer;
+import net.minecraft.world.gen.layer.ZoomLayer;
 
 import java.util.function.LongFunction;
 
 public class AtumLayerUtil {
-    public static final int SAND_PLAINS = DimensionHelper.getBiomeID(AtumBiomes.SAND_PLAINS);
-    public static final int OASIS = DimensionHelper.getBiomeID(AtumBiomes.OASIS);
-    public static final int DEAD_OASIS = DimensionHelper.getBiomeID(AtumBiomes.DEAD_OASIS);
-    public static final int DRIED_RIVER_ID = DimensionHelper.getBiomeID(AtumBiomes.DRIED_RIVER);
+    public static int SAND_PLAINS;
+    public static int OASIS;
+    public static int DEAD_OASIS;
+    public static int DRIED_RIVER_ID;
 
-    public static <T extends IArea, C extends IExtendedNoiseRandom<T>> IAreaFactory<T> buildAtumLayers(int biomeSize, int riverSize, LongFunction<C> context) {
+    public static <T extends IArea, C extends IExtendedNoiseRandom<T>> IAreaFactory<T> buildAtumLayers(int biomeSize, int riverSize, LongFunction<C> context, Registry<Biome> biomeRegistry) {
         IAreaFactory<T> layer = IslandLayer.INSTANCE.apply(context.apply(1L));
         layer = ZoomLayer.FUZZY.apply(context.apply(2000L), layer);
         layer = ZoomLayer.NORMAL.apply(context.apply(2001L), layer);
@@ -27,7 +36,7 @@ public class AtumLayerUtil {
         layer = LayerUtil.repeat(1000L, ZoomLayer.NORMAL, layer, 0, context);
         IAreaFactory<T> zoomLayer = LayerUtil.repeat(1000L, ZoomLayer.NORMAL, layer, 0, context);
         zoomLayer = StartRiverLayer.INSTANCE.apply(context.apply(100L), zoomLayer);
-        IAreaFactory<T> biomeLayer = getBiomeLayer(layer, context);
+        IAreaFactory<T> biomeLayer = getBiomeLayer(layer, context, biomeRegistry);
         IAreaFactory<T> zoomLayerNormal = LayerUtil.repeat(1000L, ZoomLayer.NORMAL, zoomLayer, 2, context);
         biomeLayer = HillsLayer.INSTANCE.apply(context.apply(1000L), biomeLayer, zoomLayerNormal);
         zoomLayer = LayerUtil.repeat(1000L, ZoomLayer.NORMAL, zoomLayer, 2, context);
@@ -49,16 +58,29 @@ public class AtumLayerUtil {
         return biomeLayer;
     }
 
-    private static <T extends IArea, C extends IExtendedNoiseRandom<T>> IAreaFactory<T> getBiomeLayer(IAreaFactory<T> parentLayer, LongFunction<C> context) {
-        parentLayer = new AtumBiomeLayer().apply(context.apply(200L), parentLayer);
+    private static <T extends IArea, C extends IExtendedNoiseRandom<T>> IAreaFactory<T> getBiomeLayer(IAreaFactory<T> parentLayer, LongFunction<C> context, Registry<Biome> biomeRegistry) {
+        parentLayer = new AtumBiomeLayer(biomeRegistry).apply(context.apply(200L), parentLayer);
         parentLayer = LayerUtil.repeat(1000L, ZoomLayer.NORMAL, parentLayer, 2, context);
         parentLayer = EdgeBiomeLayer.INSTANCE.apply(context.apply(1000L), parentLayer);
         return parentLayer;
     }
 
-    public static Layer getNoiseLayer(long seed, int biomeSize, int riverSize) {
+    public static Layer getNoiseLayer(long seed, int biomeSize, int riverSize, Registry<Biome> biomeRegistry) {
+        setupBiomeIntIDs(biomeRegistry);
+
         int maxCacheSize = 25;
-        IAreaFactory<LazyArea> layer = buildAtumLayers(biomeSize, riverSize, (p_227473_2_) -> new LazyAreaLayerContext(maxCacheSize, seed, p_227473_2_));
+        IAreaFactory<LazyArea> layer = buildAtumLayers(biomeSize, riverSize, (p_227473_2_) -> new LazyAreaLayerContext(maxCacheSize, seed, p_227473_2_), biomeRegistry);
         return new Layer(layer);
+    }
+
+    /**
+     * Always call this in the Biome Source's constructor so we get the correct int biome id for this world.
+     * (this is because the int id for the biome in the dynamic registry can be different in a different world)
+     */
+    private static void setupBiomeIntIDs(Registry<Biome> biomeRegistry) {
+        SAND_PLAINS = biomeRegistry.getId(biomeRegistry.getValueForKey(AtumBiomes.SAND_PLAINS));
+        OASIS = biomeRegistry.getId(biomeRegistry.getValueForKey(AtumBiomes.OASIS));
+        DEAD_OASIS = biomeRegistry.getId(biomeRegistry.getValueForKey(AtumBiomes.DEAD_OASIS));
+        DRIED_RIVER_ID = biomeRegistry.getId(biomeRegistry.getValueForKey(AtumBiomes.DRIED_RIVER));
     }
 }

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -2,6 +2,7 @@
 public net.minecraft.world.storage.DerivedWorldInfo field_76115_a # delegate
 public net.minecraft.world.server.ChunkManager func_223491_f()Ljava/lang/Iterable; # getLoadedChunksIterable
 public net.minecraft.world.server.ChunkManager func_219243_d(Lnet/minecraft/util/math/ChunkPos;)Z # isOutsideSpawningRadius
+public net.minecraft.world.gen.layer.Layer field_215742_b # lazyArea
 
 #Worldgen
 protected net.minecraft.world.gen.feature.TreeFeature func_225557_a_(Lnet/minecraft/world/gen/IWorldGenerationReader;Ljava/util/Random;Lnet/minecraft/util/math/BlockPos;Ljava/util/Set;Ljava/util/Set;Lnet/minecraft/util/math/MutableBoundingBox;Lnet/minecraft/world/gen/feature/BaseTreeFeatureConfig;)Z # place


### PR DESCRIPTION
Alright bare with me here. This can be a bit tricky to explain lol. the issue I found is that Repurposed Structures's (my mod) structures are being added to atum's dimension but the /locate command is broken in atum's dimension

Now this is actually a common bug and I know the exact cause. Specifically, the atum's Biome Source and layers are using the wrong registry of biomes to create the biome list and return the biome from the biome source. When /locate command is ran, it goes to the Biome Source's list of biomes first, check if any biome has the structure, and then it will start searching for the biome in chunks. Since the command is saying structure not found right away, it must be failing at that first check. 

In the biome source's constructor, the super constructor requires a list of all biomes that your biome source can spawn. And the registry parameter above for the constructor is the dynamic registry biomes. This registry is what you need to save into a field and use for everything biome related in the biome source and biome layers. Using the WorldGenRegistry or Forge Registry for biomes will return the wrong biome instance because the game creates a deep copy of all those biomes for the dynamic registry that is actually used in the world. 

Now there's probably even more edge case issues with using the worldgenregistry/forge registry of biomes in the layers that I didn't specifically look for but now with this pr, the layers now uses the dynamic registry of biomes like the game expects so that should be good. I did try to keep the layer part of the code as close to untouched as I can but you can refactor it to be cleaner if you wish. 

Hope this helps!