### PR TITLE
setup mixins and get default world seed for dimension

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,13 +3,16 @@ buildscript {
         maven { url = 'https://files.minecraftforge.net/maven' }
         jcenter()
         mavenCentral()
+        maven { url = 'https://repo.spongepowered.org/repository/maven-public/' }
     }
     dependencies {
         classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '4.1.+', changing: true
+        classpath 'org.spongepowered:mixingradle:0.7-SNAPSHOT'
     }
 }
 apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'maven-publish'
+apply plugin: 'org.spongepowered.mixin'
 
 import groovy.json.JsonSlurper
 import groovy.json.JsonOutput
@@ -54,6 +57,7 @@ minecraft {
     runs {
         client {
             workingDirectory project.file('run')
+            arg "-mixin.config=atum.mixins.json"
             property 'mixin.env.remapRefMap', 'true'
             property 'mixin.env.refMapRemappingFile', "${projectDir}/build/createSrgToMcp/output.srg"
             mods {
@@ -64,6 +68,7 @@ minecraft {
         }
         server {
             workingDirectory project.file('run')
+            arg "-mixin.config=atum.mixins.json"
             property 'mixin.env.remapRefMap', 'true'
             property 'mixin.env.refMapRemappingFile', "${projectDir}/build/createSrgToMcp/output.srg"
             mods {
@@ -96,11 +101,15 @@ dependencies {
     implementation fg.deobf("com.telepathicgrunt:Blame:1.16.5-3.0.2-forge")
 }
 
+mixin {
+    add sourceSets.main, "atum.refmap.json"
+}
 
 jar {
     manifest {
         attributes([
-            "Implementation-Version": "${version}"
+            "Implementation-Version": "${version}",
+            "MixinConfigs": "atum.mixins.json"
         ])
     }
 }

--- a/src/main/java/com/teammetallurgy/atum/misc/WorldSeedHolder.java
+++ b/src/main/java/com/teammetallurgy/atum/misc/WorldSeedHolder.java
@@ -1,0 +1,18 @@
+package com.teammetallurgy.atum.misc;
+
+public class WorldSeedHolder {
+    /**
+     * World seed for worldgen when not specified by JSON by Haven King
+     * https://github.com/Hephaestus-Dev/seedy-behavior/blob/master/src/main/java/dev/hephaestus/seedy/mixin/world/gen/GeneratorOptionsMixin.java
+     */
+    private static long SEED = 0;
+
+    public static long getSeed() {
+        return SEED;
+    }
+
+    public static long setSeed(long seed) {
+        SEED = seed;
+        return seed;
+    }
+}

--- a/src/main/java/com/teammetallurgy/atum/mixin/DimensionGeneratorSettingsMixin.java
+++ b/src/main/java/com/teammetallurgy/atum/mixin/DimensionGeneratorSettingsMixin.java
@@ -1,0 +1,26 @@
+package com.teammetallurgy.atum.mixin;
+
+import com.teammetallurgy.atum.misc.WorldSeedHolder;
+import net.minecraft.util.registry.SimpleRegistry;
+import net.minecraft.world.Dimension;
+import net.minecraft.world.gen.settings.DimensionGeneratorSettings;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Optional;
+
+@Mixin(DimensionGeneratorSettings.class)
+public class DimensionGeneratorSettingsMixin {
+
+	/**
+	 * World seed for worldgen when not specified by JSON by Haven King
+	 * https://github.com/Hephaestus-Dev/seedy-behavior/blob/master/src/main/java/dev/hephaestus/seedy/mixin/world/gen/GeneratorOptionsMixin.java
+	 */
+	@Inject(method = "<init>(JZZLnet/minecraft/util/registry/SimpleRegistry;Ljava/util/Optional;)V",
+			at = @At(value = "RETURN"))
+	private void atum_giveUsRandomSeeds(long seed, boolean generateFeatures, boolean bonusChest, SimpleRegistry<Dimension> registry, Optional<String> s, CallbackInfo ci) {
+		WorldSeedHolder.setSeed(seed);
+	}
+}

--- a/src/main/java/com/teammetallurgy/atum/world/gen/AtumChunkGenerator.java
+++ b/src/main/java/com/teammetallurgy/atum/world/gen/AtumChunkGenerator.java
@@ -2,6 +2,7 @@ package com.teammetallurgy.atum.world.gen;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.teammetallurgy.atum.misc.WorldSeedHolder;
 import com.teammetallurgy.atum.world.DimensionHelper;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectList;
@@ -50,6 +51,8 @@ public class AtumChunkGenerator extends ChunkGenerator { //Copied from NoiseChun
             return chunkGenerator.biomeProvider;
         }), DimensionSettings.field_236098_b_.fieldOf("settings").forGetter((chunkGenerator) -> {
             return chunkGenerator.dimensionSettings;
+        }), Codec.LONG.fieldOf("seed").orElseGet(WorldSeedHolder::getSeed).forGetter((chunkGenerator) -> {
+            return chunkGenerator.seed;
         })).apply(c, c.stable(AtumChunkGenerator::new));
     });
     private static final float[] field_222561_h = Util.make(new float[13824], (p_236094_0_) -> {
@@ -91,8 +94,8 @@ public class AtumChunkGenerator extends ChunkGenerator { //Copied from NoiseChun
     protected final Supplier<DimensionSettings> dimensionSettings;
     private final int worldHeight;
 
-    public AtumChunkGenerator(BiomeProvider biomeProvider, Supplier<DimensionSettings> dimensionSettings) {
-        this(biomeProvider, biomeProvider, (new Random()).nextLong(), dimensionSettings); //Set random seed
+    public AtumChunkGenerator(BiomeProvider biomeProvider, Supplier<DimensionSettings> dimensionSettings, long seed) {
+        this(biomeProvider, biomeProvider, seed, dimensionSettings); //Set random seed
     }
 
     private AtumChunkGenerator(BiomeProvider biomeProvider1, BiomeProvider biomeProvider2, long seed, Supplier<DimensionSettings> dimensionSettings) {
@@ -135,7 +138,7 @@ public class AtumChunkGenerator extends ChunkGenerator { //Copied from NoiseChun
     @OnlyIn(Dist.CLIENT)
     @Nonnull
     public ChunkGenerator func_230349_a_(long seed) {
-        return new AtumChunkGenerator(this.biomeProvider.getBiomeProvider(seed), this.dimensionSettings);
+        return new AtumChunkGenerator(this.biomeProvider.getBiomeProvider(seed), this.dimensionSettings, this.seed);
     }
 
     public boolean func_236088_a_(long p_236088_1_, RegistryKey<DimensionSettings> dimensionSettings) {

--- a/src/main/resources/atum.mixins.json
+++ b/src/main/resources/atum.mixins.json
@@ -1,0 +1,13 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "com.teammetallurgy.atum.mixin",
+  "refmap": "atum.refmap.json",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+    "DimensionGeneratorSettingsMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}


### PR DESCRIPTION
this should now make all new atum worlds never have chunk borders anymore as it will grab the world's seed if the dimension datapack file does not have a seed field (in you case, it doesn't so default world seed it is!)

The forge pr I made to expose the default seed is #7950. I didn't link the full URL so that this pr doesn't show up there as the forge team really dislikes mixin solutions being linked to a forge pr. 

You do not need to merge this if you don't want to but it's here if you wanted to see how to setup mixins and get the seed for this use case!