### PR TITLE
Allow IFogReductionItem to not require extending ArmorItem

### DIFF
--- a/src/main/java/com/teammetallurgy/atum/api/IFogReductionItem.java
+++ b/src/main/java/com/teammetallurgy/atum/api/IFogReductionItem.java
@@ -2,13 +2,13 @@ package com.teammetallurgy.atum.api;
 
 import com.google.common.collect.Lists;
 import net.minecraft.inventory.EquipmentSlotType;
-import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 
 import java.util.List;
 
 public interface IFogReductionItem {
 
-    float getFogReduction(float fogDensity, Item armorItem);
+    float getFogReduction(float fogDensity, ItemStack armorItem);
 
     default List<EquipmentSlotType> getSlotTypes() {
         return Lists.newArrayList(EquipmentSlotType.HEAD);

--- a/src/main/java/com/teammetallurgy/atum/client/ClientEvents.java
+++ b/src/main/java/com/teammetallurgy/atum/client/ClientEvents.java
@@ -19,7 +19,6 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.MobEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.EquipmentSlotType;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.RegistryKey;
 import net.minecraft.util.ResourceLocation;
@@ -66,10 +65,9 @@ public class ClientEvents {
                 for (ItemStack armor : player.getArmorInventoryList()) {
                     if (armor.getItem() instanceof IFogReductionItem) {
                         EquipmentSlotType slotType = MobEntity.getSlotForItemStack(armor);
-                        Item armorItem = armor.getItem();
                         IFogReductionItem fogReductionItem = (IFogReductionItem) armor.getItem();
                         if (fogReductionItem.getSlotTypes().contains(slotType)) {
-                            fogDensity = fogReductionItem.getFogReduction(fogDensity, armorItem);
+                            fogDensity = fogReductionItem.getFogReduction(fogDensity, armor);
                         }
                     }
                 }

--- a/src/main/java/com/teammetallurgy/atum/items/WandererDyeableArmor.java
+++ b/src/main/java/com/teammetallurgy/atum/items/WandererDyeableArmor.java
@@ -24,7 +24,7 @@ public class WandererDyeableArmor extends TexturedArmorItem implements IDyeableA
     }
 
     @Override
-    public float getFogReduction(float fogDensity, Item armorItem) {
+    public float getFogReduction(float fogDensity, ItemStack armorItem) {
         return fogDensity / 2.0F;
     }
 }

--- a/src/main/java/com/teammetallurgy/atum/items/artifacts/ArtifactArmor.java
+++ b/src/main/java/com/teammetallurgy/atum/items/artifacts/ArtifactArmor.java
@@ -154,7 +154,7 @@ public abstract class ArtifactArmor extends TexturedArmorItem implements IArtifa
     }
 
     @Override
-    public float getFogReduction(float fogDensity, Item armorItem) {
+    public float getFogReduction(float fogDensity, ItemStack armorItem) {
         return fogDensity / 3.25F;
     }
 }


### PR DESCRIPTION
Some items like pumpkins are able to be equipped as armour without extending ArmorItem.