### PR TITLE
Standardise use of static LockableLootTileEntity::setTable.

### DIFF
--- a/src/main/java/com/teammetallurgy/atum/world/gen/structure/girafitomb/GirafiTombPieces.java
+++ b/src/main/java/com/teammetallurgy/atum/world/gen/structure/girafitomb/GirafiTombPieces.java
@@ -9,6 +9,7 @@ import com.teammetallurgy.atum.init.AtumLootTables;
 import com.teammetallurgy.atum.init.AtumStructurePieces;
 import net.minecraft.block.Blocks;
 import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.tileentity.LockableLootTileEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Mirror;
 import net.minecraft.util.ResourceLocation;
@@ -59,10 +60,7 @@ public class GirafiTombPieces {
                     if (rand.nextDouble() <= 0.15D) {
                         world.setBlockState(pos, ChestBaseBlock.correctFacing(world, pos, AtumBlocks.DEADWOOD_CRATE.getDefaultState(), AtumBlocks.DEADWOOD_CRATE), 2);
 
-                        TileEntity tileEntity = world.getTileEntity(pos);
-                        if (tileEntity instanceof CrateTileEntity) {
-                            ((CrateTileEntity) tileEntity).setLootTable(AtumLootTables.CRATE, rand.nextLong());
-                        }
+                        LockableLootTileEntity.setLootTable(world, rand, pos, AtumLootTables.CRATE);
                     } else {
                         world.setBlockState(pos, Blocks.AIR.getDefaultState(), 2);
                     }
@@ -70,19 +68,13 @@ public class GirafiTombPieces {
             } else if (function.equals("GirafiSarcophagus")) {
                 BlockPos posDown = pos.down();
                 if (box.isVecInside(posDown)) {
-                    TileEntity tileentity = world.getTileEntity(posDown);
-                    if (tileentity instanceof SarcophagusTileEntity) {
-                        ((SarcophagusTileEntity) tileentity).setLootTable(AtumLootTables.GIRAFI_TOMB, rand.nextLong());
-                    }
+                    LockableLootTileEntity.setLootTable(world, rand, posDown, AtumLootTables.GIRAFI_TOMB);
                     world.setBlockState(pos, Blocks.AIR.getDefaultState(), 2);
                 }
             } else if (function.equals("Sarcophagus")) {
                 BlockPos posDown = pos.down();
                 if (box.isVecInside(posDown)) {
-                    TileEntity tileentity = world.getTileEntity(posDown);
-                    if (tileentity instanceof SarcophagusTileEntity) {
-                        ((SarcophagusTileEntity) tileentity).setLootTable(AtumLootTables.PHARAOH, rand.nextLong());
-                    }
+                    LockableLootTileEntity.setLootTable(world, rand, posDown, AtumLootTables.PHARAOH);
                     world.setBlockState(pos, Blocks.AIR.getDefaultState(), 2);
                 }
             }

--- a/src/main/java/com/teammetallurgy/atum/world/gen/structure/pyramid/PyramidPieces.java
+++ b/src/main/java/com/teammetallurgy/atum/world/gen/structure/pyramid/PyramidPieces.java
@@ -22,6 +22,7 @@ import net.minecraft.block.Blocks;
 import net.minecraft.block.LadderBlock;
 import net.minecraft.entity.EntityType;
 import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.tileentity.LockableLootTileEntity;
 import net.minecraft.tileentity.MobSpawnerTileEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
@@ -193,11 +194,7 @@ public class PyramidPieces {
                 if (box.isVecInside(pos)) {
                     if (rand.nextDouble() <= 0.2D) {
                         world.setBlockState(pos, ChestBaseBlock.correctFacing(world, pos, AtumBlocks.DEADWOOD_CRATE.getDefaultState(), AtumBlocks.DEADWOOD_CRATE), 2);
-
-                        TileEntity tileEntity = world.getTileEntity(pos);
-                        if (tileEntity instanceof CrateTileEntity) {
-                            ((CrateTileEntity) tileEntity).setLootTable(AtumLootTables.CRATE, rand.nextLong());
-                        }
+                        LockableLootTileEntity.setLootTable(world, rand, pos, AtumLootTables.CRATE);
                     } else {
                         world.setBlockState(pos, Blocks.AIR.getDefaultState(), 2);
                     }
@@ -205,19 +202,13 @@ public class PyramidPieces {
             } else if (function.equals("Chest")) {
                 BlockPos posDown = pos.down();
                 if (box.isVecInside(posDown)) {
-                    TileEntity tileentity = world.getTileEntity(posDown);
-                    if (tileentity instanceof LimestoneChestTileEntity) {
-                        ((LimestoneChestTileEntity) tileentity).setLootTable(AtumLootTables.PYRAMID_CHEST, rand.nextLong());
-                    }
+                    LockableLootTileEntity.setLootTable(world, rand, posDown, AtumLootTables.PYRAMID_CHEST);
                 }
                 world.setBlockState(pos, Blocks.AIR.getDefaultState(), 2);
             } else if (function.equals("Sarcophagus")) {
                 BlockPos posDown = pos.down();
                 if (box.isVecInside(posDown)) {
-                    TileEntity tileentity = world.getTileEntity(posDown);
-                    if (tileentity instanceof SarcophagusTileEntity) {
-                        ((SarcophagusTileEntity) tileentity).setLootTable(AtumLootTables.PHARAOH, rand.nextLong());
-                    }
+                    LockableLootTileEntity.setLootTable(world, rand, posDown, AtumLootTables.PHARAOH);
                 }
                 world.setBlockState(pos, Blocks.AIR.getDefaultState(), 2);
             } else if (function.equals("NebuTorch")) {

--- a/src/main/java/com/teammetallurgy/atum/world/gen/structure/ruins/RuinPieces.java
+++ b/src/main/java/com/teammetallurgy/atum/world/gen/structure/ruins/RuinPieces.java
@@ -11,6 +11,7 @@ import com.teammetallurgy.atum.misc.AtumConfig;
 import net.minecraft.block.Blocks;
 import net.minecraft.entity.EntityType;
 import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.tileentity.LockableLootTileEntity;
 import net.minecraft.tileentity.MobSpawnerTileEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
@@ -82,11 +83,7 @@ public class RuinPieces {
                 if (box.isVecInside(pos)) {
                     if (rand.nextDouble() <= 0.15D) {
                         world.setBlockState(pos, ChestBaseBlock.correctFacing(world, pos, AtumBlocks.DEADWOOD_CRATE.getDefaultState(), AtumBlocks.DEADWOOD_CRATE), 2);
-
-                        TileEntity tileEntity = world.getTileEntity(pos);
-                        if (tileEntity instanceof CrateTileEntity) {
-                            ((CrateTileEntity) tileEntity).setLootTable(AtumLootTables.CRATE, rand.nextLong());
-                        }
+                        LockableLootTileEntity.setLootTable(world, rand, pos, AtumLootTables.CRATE);
                     } else {
                         world.setBlockState(pos, Blocks.AIR.getDefaultState(), 2);
                     }

--- a/src/main/java/com/teammetallurgy/atum/world/gen/structure/tomb/TombPieces.java
+++ b/src/main/java/com/teammetallurgy/atum/world/gen/structure/tomb/TombPieces.java
@@ -10,6 +10,7 @@ import com.teammetallurgy.atum.init.AtumStructurePieces;
 import com.teammetallurgy.atum.world.gen.structure.ruins.RuinPieces;
 import net.minecraft.block.Blocks;
 import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.tileentity.LockableLootTileEntity;
 import net.minecraft.tileentity.MobSpawnerTileEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Mirror;
@@ -71,10 +72,7 @@ public class TombPieces {
                     if (rand.nextDouble() < 0.2D) {
                         world.setBlockState(pos, Blocks.AIR.getDefaultState(), 2); //Set structure block to air, to remove its TE
                         world.setBlockState(pos, ChestBaseBlock.correctFacing(world, pos, AtumBlocks.DEADWOOD_CRATE.getDefaultState(), AtumBlocks.DEADWOOD_CRATE), 2);
-                        TileEntity tileEntity = world.getTileEntity(pos);
-                        if (tileEntity instanceof CrateTileEntity) {
-                            ((CrateTileEntity) tileEntity).setLootTable(AtumLootTables.CRATE, rand.nextLong());
-                        }
+                        LockableLootTileEntity.setLootTable(world, rand, pos, AtumLootTables.CRATE);
                     } else {
                         world.setBlockState(pos, Blocks.AIR.getDefaultState(), 2);
                     }
@@ -82,10 +80,7 @@ public class TombPieces {
             } else if (function.equals("Chest")) {
                 BlockPos posDown = pos.down();
                 if (box.isVecInside(posDown)) {
-                    TileEntity tileentity = world.getTileEntity(posDown);
-                    if (tileentity instanceof LimestoneChestTileEntity) {
-                        ((LimestoneChestTileEntity) tileentity).setLootTable(AtumLootTables.TOMB_CHEST, rand.nextLong());
-                    }
+                    LockableLootTileEntity.setLootTable(world, rand, posDown, AtumLootTables.TOMB_CHEST);
                 }
                 world.setBlockState(pos, Blocks.AIR.getDefaultState(), 2);
             }


### PR DESCRIPTION
Introduces Lootr support for some additional containers.

This changes nothing, as the code for the static method checks for an instance of LockableLootTileEntity first. Likewise, while it does affect sarcophagus blocks, etc, that will have no interaction with Lootr as those blocks aren't set to be replaced (hopefully).